### PR TITLE
WeekPicker -> IntervalPicker

### DIFF
--- a/optaweb-employee-rostering-frontend/src/ui/components/IntervalPicker.css
+++ b/optaweb-employee-rostering-frontend/src/ui/components/IntervalPicker.css
@@ -13,11 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- .week-picker-container {
+ .interval-picker-container {
     background-color: var(--pf-global--BackgroundColor--100);
  }
 
-.week-picker {
+.interval-picker {
     z-index: 100;
     background-color: var(--pf-global--BackgroundColor--200);
 }

--- a/optaweb-employee-rostering-frontend/src/ui/components/IntervalPicker.css
+++ b/optaweb-employee-rostering-frontend/src/ui/components/IntervalPicker.css
@@ -21,3 +21,7 @@
     z-index: 100;
     background-color: var(--pf-global--BackgroundColor--200);
 }
+
+.interval-picker-toggle {
+    display: inline;
+}

--- a/optaweb-employee-rostering-frontend/src/ui/components/IntervalPicker.test.tsx
+++ b/optaweb-employee-rostering-frontend/src/ui/components/IntervalPicker.test.tsx
@@ -29,20 +29,34 @@ describe('IntervalPicker component', () => {
     moment.locale('en');
   });
 
+  function makeIntervalPicker(
+    onChange: (start: Date, end: Date) => void,
+    onIntervalChange: (interval: 'day' | 'week' | 'month') => void = jest.fn(),
+  ) {
+    return shallow(
+      <IntervalPicker
+        interval="week"
+        value={moment('2019-07-03').toDate()}
+        onChange={onChange}
+        onIntervalChange={onIntervalChange}
+      />,
+    );
+  }
+
   it('should render correctly when closed', () => {
-    const intervalPicker = shallow(<IntervalPicker value={moment('2019-07-03').toDate()} onChange={jest.fn()} />);
+    const intervalPicker = makeIntervalPicker(jest.fn());
     expect(toJson(intervalPicker)).toMatchSnapshot();
   });
 
   it('should render correctly when opened', () => {
-    const intervalPicker = shallow(<IntervalPicker value={moment('2019-07-03').toDate()} onChange={jest.fn()} />);
+    const intervalPicker = makeIntervalPicker(jest.fn());
     intervalPicker.setState({ isOpen: true });
     expect(toJson(intervalPicker)).toMatchSnapshot();
   });
 
   it('should pass previous interval to onChange when previous interval is clicked', () => {
     const onChange = jest.fn();
-    const intervalPicker = shallow(<IntervalPicker value={moment('2019-07-03').toDate()} onChange={onChange} />);
+    const intervalPicker = makeIntervalPicker(onChange);
     intervalPicker.find('[aria-label="Previous Interval"]').simulate('click');
     expect(onChange).toBeCalled();
     expect(onChange)
@@ -51,7 +65,7 @@ describe('IntervalPicker component', () => {
 
   it('should pass next interval to onChange when next interval is clicked', () => {
     const onChange = jest.fn();
-    const intervalPicker = shallow(<IntervalPicker value={moment('2019-07-03').toDate()} onChange={onChange} />);
+    const intervalPicker = makeIntervalPicker(onChange);
     intervalPicker.find('[aria-label="Next Interval"]').simulate('click');
     expect(onChange).toBeCalled();
     expect(onChange)
@@ -62,7 +76,7 @@ describe('IntervalPicker component', () => {
     const solvingStartTime = moment('2019-07-23').toDate();
     MockDate.set(solvingStartTime);
     const onChange = jest.fn();
-    const intervalPicker = shallow(<IntervalPicker value={moment('2019-07-03').toDate()} onChange={onChange} />);
+    const intervalPicker = makeIntervalPicker(onChange);
     ((intervalPicker.find(DatePicker).props() as any).onChange as Function)({} as React.FormEvent);
     expect(onChange).toBeCalled();
     expect(onChange)
@@ -71,7 +85,7 @@ describe('IntervalPicker component', () => {
 
   it('should go to the week containing a day when the day is clicked', () => {
     const onChange = jest.fn();
-    const intervalPicker = shallow(<IntervalPicker value={moment('2019-07-03').toDate()} onChange={onChange} />);
+    const intervalPicker = makeIntervalPicker(onChange);
     ((intervalPicker.find(DatePicker).props() as any).onClickDay as Function)(moment('2019-07-30').toDate());
     expect(onChange).toBeCalled();
     expect(onChange)
@@ -80,20 +94,53 @@ describe('IntervalPicker component', () => {
 
   it('should open when opened', () => {
     const onChange = jest.fn();
-    const intervalPicker = shallow(<IntervalPicker value={moment('2019-07-03').toDate()} onChange={onChange} />);
+    const intervalPicker = makeIntervalPicker(onChange);
     ((intervalPicker.find(DatePicker).props() as any).onCalendarOpen as Function)();
-    expect(intervalPicker.instance().state).toEqual({
+    expect(intervalPicker.instance().state).toMatchObject({
       isOpen: true,
     });
   });
 
   it('should closed when closed', () => {
     const onChange = jest.fn();
-    const intervalPicker = shallow(<IntervalPicker value={moment('2019-07-03').toDate()} onChange={onChange} />);
+    const intervalPicker = makeIntervalPicker(onChange);
     intervalPicker.setState({ isOpen: true });
     ((intervalPicker.find(DatePicker).props() as any).onCalendarClose as Function)();
-    expect(intervalPicker.instance().state).toEqual({
+    expect(intervalPicker.instance().state).toMatchObject({
       isOpen: false,
     });
+  });
+
+  it('should change interval to day', () => {
+    const onIntervalChange = jest.fn();
+    const intervalPicker = makeIntervalPicker(jest.fn(), onIntervalChange);
+    intervalPicker.setState({ interval: 'week' });
+    intervalPicker.find('[aria-label="Day"]').simulate('click');
+    expect(intervalPicker.instance().state).toMatchObject({
+      interval: 'day',
+    });
+    expect(onIntervalChange).toBeCalledWith('day');
+  });
+
+  it('should change interval to week', () => {
+    const onIntervalChange = jest.fn();
+    const intervalPicker = makeIntervalPicker(jest.fn(), onIntervalChange);
+    intervalPicker.setState({ interval: 'day' });
+    intervalPicker.find('[aria-label="Week"]').simulate('click');
+    expect(intervalPicker.instance().state).toMatchObject({
+      interval: 'week',
+    });
+    expect(onIntervalChange).toBeCalledWith('week');
+  });
+
+  it('should change interval to month', () => {
+    const onIntervalChange = jest.fn();
+    const intervalPicker = makeIntervalPicker(jest.fn(), onIntervalChange);
+    intervalPicker.setState({ interval: 'week' });
+    intervalPicker.find('[aria-label="Month"]').simulate('click');
+    expect(intervalPicker.instance().state).toMatchObject({
+      interval: 'month',
+    });
+    expect(onIntervalChange).toBeCalledWith('month');
   });
 });

--- a/optaweb-employee-rostering-frontend/src/ui/components/IntervalPicker.test.tsx
+++ b/optaweb-employee-rostering-frontend/src/ui/components/IntervalPicker.test.tsx
@@ -22,37 +22,37 @@ import moment from 'moment-timezone';
 import 'moment/locale/en-ca';
 
 import MockDate from 'mockdate';
-import WeekPicker from './WeekPicker';
+import IntervalPicker from './IntervalPicker';
 
-describe('WeekPicker component', () => {
+describe('IntervalPicker component', () => {
   beforeAll(() => {
     moment.locale('en');
   });
 
   it('should render correctly when closed', () => {
-    const weekPicker = shallow(<WeekPicker value={moment('2019-07-03').toDate()} onChange={jest.fn()} />);
-    expect(toJson(weekPicker)).toMatchSnapshot();
+    const intervalPicker = shallow(<IntervalPicker value={moment('2019-07-03').toDate()} onChange={jest.fn()} />);
+    expect(toJson(intervalPicker)).toMatchSnapshot();
   });
 
   it('should render correctly when opened', () => {
-    const weekPicker = shallow(<WeekPicker value={moment('2019-07-03').toDate()} onChange={jest.fn()} />);
-    weekPicker.setState({ isOpen: true });
-    expect(toJson(weekPicker)).toMatchSnapshot();
+    const intervalPicker = shallow(<IntervalPicker value={moment('2019-07-03').toDate()} onChange={jest.fn()} />);
+    intervalPicker.setState({ isOpen: true });
+    expect(toJson(intervalPicker)).toMatchSnapshot();
   });
 
-  it('should pass previous week to onChange when previous week is clicked', () => {
+  it('should pass previous interval to onChange when previous interval is clicked', () => {
     const onChange = jest.fn();
-    const weekPicker = shallow(<WeekPicker value={moment('2019-07-03').toDate()} onChange={onChange} />);
-    weekPicker.find('[aria-label="Previous Week"]').simulate('click');
+    const intervalPicker = shallow(<IntervalPicker value={moment('2019-07-03').toDate()} onChange={onChange} />);
+    intervalPicker.find('[aria-label="Previous Interval"]').simulate('click');
     expect(onChange).toBeCalled();
     expect(onChange)
       .toBeCalledWith(moment('2019-06-23').toDate(), moment('2019-06-23').endOf('week').toDate());
   });
 
-  it('should pass next week to onChange when next week is clicked', () => {
+  it('should pass next interval to onChange when next interval is clicked', () => {
     const onChange = jest.fn();
-    const weekPicker = shallow(<WeekPicker value={moment('2019-07-03').toDate()} onChange={onChange} />);
-    weekPicker.find('[aria-label="Next Week"]').simulate('click');
+    const intervalPicker = shallow(<IntervalPicker value={moment('2019-07-03').toDate()} onChange={onChange} />);
+    intervalPicker.find('[aria-label="Next Interval"]').simulate('click');
     expect(onChange).toBeCalled();
     expect(onChange)
       .toBeCalledWith(moment('2019-07-07').toDate(), moment('2019-07-07').endOf('week').toDate());
@@ -62,8 +62,8 @@ describe('WeekPicker component', () => {
     const solvingStartTime = moment('2019-07-23').toDate();
     MockDate.set(solvingStartTime);
     const onChange = jest.fn();
-    const weekPicker = shallow(<WeekPicker value={moment('2019-07-03').toDate()} onChange={onChange} />);
-    ((weekPicker.find(DatePicker).props() as any).onChange as Function)({} as React.FormEvent);
+    const intervalPicker = shallow(<IntervalPicker value={moment('2019-07-03').toDate()} onChange={onChange} />);
+    ((intervalPicker.find(DatePicker).props() as any).onChange as Function)({} as React.FormEvent);
     expect(onChange).toBeCalled();
     expect(onChange)
       .toBeCalledWith(moment('2019-07-21').toDate(), moment('2019-07-21').endOf('week').toDate());
@@ -71,8 +71,8 @@ describe('WeekPicker component', () => {
 
   it('should go to the week containing a day when the day is clicked', () => {
     const onChange = jest.fn();
-    const weekPicker = shallow(<WeekPicker value={moment('2019-07-03').toDate()} onChange={onChange} />);
-    ((weekPicker.find(DatePicker).props() as any).onClickDay as Function)(moment('2019-07-30').toDate());
+    const intervalPicker = shallow(<IntervalPicker value={moment('2019-07-03').toDate()} onChange={onChange} />);
+    ((intervalPicker.find(DatePicker).props() as any).onClickDay as Function)(moment('2019-07-30').toDate());
     expect(onChange).toBeCalled();
     expect(onChange)
       .toBeCalledWith(moment('2019-07-28').toDate(), moment('2019-07-28').endOf('week').toDate());
@@ -80,19 +80,19 @@ describe('WeekPicker component', () => {
 
   it('should open when opened', () => {
     const onChange = jest.fn();
-    const weekPicker = shallow(<WeekPicker value={moment('2019-07-03').toDate()} onChange={onChange} />);
-    ((weekPicker.find(DatePicker).props() as any).onCalendarOpen as Function)();
-    expect(weekPicker.instance().state).toEqual({
+    const intervalPicker = shallow(<IntervalPicker value={moment('2019-07-03').toDate()} onChange={onChange} />);
+    ((intervalPicker.find(DatePicker).props() as any).onCalendarOpen as Function)();
+    expect(intervalPicker.instance().state).toEqual({
       isOpen: true,
     });
   });
 
   it('should closed when closed', () => {
     const onChange = jest.fn();
-    const weekPicker = shallow(<WeekPicker value={moment('2019-07-03').toDate()} onChange={onChange} />);
-    weekPicker.setState({ isOpen: true });
-    ((weekPicker.find(DatePicker).props() as any).onCalendarClose as Function)();
-    expect(weekPicker.instance().state).toEqual({
+    const intervalPicker = shallow(<IntervalPicker value={moment('2019-07-03').toDate()} onChange={onChange} />);
+    intervalPicker.setState({ isOpen: true });
+    ((intervalPicker.find(DatePicker).props() as any).onCalendarClose as Function)();
+    expect(intervalPicker.instance().state).toEqual({
       isOpen: false,
     });
   });

--- a/optaweb-employee-rostering-frontend/src/ui/components/IntervalPicker.tsx
+++ b/optaweb-employee-rostering-frontend/src/ui/components/IntervalPicker.tsx
@@ -18,50 +18,49 @@ import React from 'react';
 import DatePicker from '@wojtekmaj/react-daterange-picker';
 import moment from 'moment';
 import { HistoryIcon } from '@patternfly/react-icons';
-import './WeekPicker.css';
+import './IntervalPicker.css';
 import { Button, ButtonVariant } from '@patternfly/react-core';
 
-export interface WeekPickerProps {
+export interface IntervalPickerProps {
   value: Date;
-  onChange: (weekStartDate: Date, weekEndDate: Date) => void;
+  onChange: (intervalStartDate: Date, intervalEndDate: Date) => void;
 }
 
-export interface WeekPickerState {
+export interface IntervalPickerState {
   isOpen: boolean;
 }
 
-function getFirstDayInWeek(dateInWeek: Date): Date {
-  return moment(dateInWeek).startOf('week').toDate();
+function getFirstDayInInterval(dateInInterval: Date): Date {
+  return moment(dateInInterval).startOf('week').toDate();
 }
 
-function getLastDayInWeek(dateInWeek: Date): Date {
-  return moment(dateInWeek).endOf('week').toDate();
+function getLastDayInInterval(dateInInterval: Date): Date {
+  return moment(dateInInterval).endOf('week').toDate();
 }
 
-export default class WeekPicker extends React.Component<WeekPickerProps, WeekPickerState> {
-  constructor(props: WeekPickerProps) {
+export default class IntervalPicker extends React.Component<IntervalPickerProps, IntervalPickerState> {
+  constructor(props: IntervalPickerProps) {
     super(props);
     this.state = { isOpen: false };
   }
 
-  goToCurrentWeek() {
-    this.props.onChange(getFirstDayInWeek(new Date()), getLastDayInWeek(new Date()));
-    this.setState({ isOpen: false });
+  goToCurrentInterval() {
+    this.goToIntervalContaining(new Date());
   }
 
-  goToWeekContaining(date: Date) {
-    this.props.onChange(getFirstDayInWeek(date), getLastDayInWeek(date));
+  goToIntervalContaining(date: Date) {
+    this.props.onChange(getFirstDayInInterval(date), getLastDayInInterval(date));
     this.setState({ isOpen: false });
   }
 
   render() {
     const locale = moment.locale();
     return (
-      <div className="week-picker-container">
+      <div className="interval-picker-container">
         <Button
-          aria-label="Previous Week"
+          aria-label="Previous Interval"
           variant={ButtonVariant.plain}
-          onClick={() => this.goToWeekContaining(moment(this.props.value).subtract(1, 'w').toDate())}
+          onClick={() => this.goToIntervalContaining(moment(this.props.value).subtract(1, 'w').toDate())}
         >
           <svg
             fill="currentColor"
@@ -83,14 +82,14 @@ export default class WeekPicker extends React.Component<WeekPickerProps, WeekPic
           </svg>
         </Button>
         <DatePicker
-          className="week-picker"
+          className="interval-picker"
           locale={
             /* moment intreprets "en" as "en-US", this intreprets "en" as "en-GB" */
             locale === 'en' ? 'en-US' : locale
           }
-          value={[getFirstDayInWeek(this.props.value), getLastDayInWeek(this.props.value)]}
-          onChange={() => this.goToCurrentWeek()}
-          onClickDay={(value: Date) => this.goToWeekContaining(value)}
+          value={[getFirstDayInInterval(this.props.value), getLastDayInInterval(this.props.value)]}
+          onChange={() => this.goToCurrentInterval()}
+          onClickDay={(value: Date) => this.goToIntervalContaining(value)}
           onCalendarOpen={() => this.setState({ isOpen: true })}
           onCalendarClose={() => this.setState({ isOpen: false })}
           isOpen={this.state.isOpen}
@@ -98,9 +97,9 @@ export default class WeekPicker extends React.Component<WeekPickerProps, WeekPic
           required
         />
         <Button
-          aria-label="Next Week"
+          aria-label="Next Interval"
           variant={ButtonVariant.plain}
-          onClick={() => this.goToWeekContaining(moment(this.props.value).add(1, 'w').toDate())}
+          onClick={() => this.goToIntervalContaining(moment(this.props.value).add(1, 'w').toDate())}
         >
           <svg
             fill="currentColor"

--- a/optaweb-employee-rostering-frontend/src/ui/components/__snapshots__/IntervalPicker.test.tsx.snap
+++ b/optaweb-employee-rostering-frontend/src/ui/components/__snapshots__/IntervalPicker.test.tsx.snap
@@ -1,11 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`WeekPicker component should render correctly when closed 1`] = `
+exports[`IntervalPicker component should render correctly when closed 1`] = `
 <div
-  className="week-picker-container"
+  className="interval-picker-container"
 >
   <Component
-    aria-label="Previous Week"
+    aria-label="Previous Interval"
     onClick={[Function]}
     variant="plain"
   >
@@ -60,7 +60,7 @@ exports[`WeekPicker component should render correctly when closed 1`] = `
         />
       </svg>
     }
-    className="week-picker"
+    className="interval-picker"
     clearIcon={
       <HistoryIcon
         color="currentColor"
@@ -85,7 +85,7 @@ exports[`WeekPicker component should render correctly when closed 1`] = `
     }
   />
   <Component
-    aria-label="Next Week"
+    aria-label="Next Interval"
     onClick={[Function]}
     variant="plain"
   >
@@ -111,12 +111,12 @@ exports[`WeekPicker component should render correctly when closed 1`] = `
 </div>
 `;
 
-exports[`WeekPicker component should render correctly when opened 1`] = `
+exports[`IntervalPicker component should render correctly when opened 1`] = `
 <div
-  className="week-picker-container"
+  className="interval-picker-container"
 >
   <Component
-    aria-label="Previous Week"
+    aria-label="Previous Interval"
     onClick={[Function]}
     variant="plain"
   >
@@ -171,7 +171,7 @@ exports[`WeekPicker component should render correctly when opened 1`] = `
         />
       </svg>
     }
-    className="week-picker"
+    className="interval-picker"
     clearIcon={
       <HistoryIcon
         color="currentColor"
@@ -196,7 +196,7 @@ exports[`WeekPicker component should render correctly when opened 1`] = `
     }
   />
   <Component
-    aria-label="Next Week"
+    aria-label="Next Interval"
     onClick={[Function]}
     variant="plain"
   >

--- a/optaweb-employee-rostering-frontend/src/ui/components/__snapshots__/IntervalPicker.test.tsx.snap
+++ b/optaweb-employee-rostering-frontend/src/ui/components/__snapshots__/IntervalPicker.test.tsx.snap
@@ -108,6 +108,31 @@ exports[`IntervalPicker component should render correctly when closed 1`] = `
       />
     </svg>
   </Component>
+  <InputGroup
+    className="interval-picker-toggle"
+  >
+    <Component
+      aria-label="Day"
+      onClick={[Function]}
+      variant="tertiary"
+    >
+      Day
+    </Component>
+    <Component
+      aria-label="Week"
+      onClick={[Function]}
+      variant="primary"
+    >
+      Week
+    </Component>
+    <Component
+      aria-label="Month"
+      onClick={[Function]}
+      variant="tertiary"
+    >
+      Month
+    </Component>
+  </InputGroup>
 </div>
 `;
 
@@ -219,5 +244,30 @@ exports[`IntervalPicker component should render correctly when opened 1`] = `
       />
     </svg>
   </Component>
+  <InputGroup
+    className="interval-picker-toggle"
+  >
+    <Component
+      aria-label="Day"
+      onClick={[Function]}
+      variant="tertiary"
+    >
+      Day
+    </Component>
+    <Component
+      aria-label="Week"
+      onClick={[Function]}
+      variant="primary"
+    >
+      Week
+    </Component>
+    <Component
+      aria-label="Month"
+      onClick={[Function]}
+      variant="tertiary"
+    >
+      Month
+    </Component>
+  </InputGroup>
 </div>
 `;

--- a/optaweb-employee-rostering-frontend/src/ui/components/calendar/Schedule.test.tsx
+++ b/optaweb-employee-rostering-frontend/src/ui/components/calendar/Schedule.test.tsx
@@ -245,6 +245,7 @@ describe('Schedule', () => {
 const props: Props<{ start: Date; end: Date; title: string }> = {
   startDate: new Date('2018-01-01T00:00'),
   endDate: new Date('2018-01-07T00:00'),
+  interval: 'week',
   events: [
     {
       title: 'Event 1',

--- a/optaweb-employee-rostering-frontend/src/ui/components/calendar/Schedule.tsx
+++ b/optaweb-employee-rostering-frontend/src/ui/components/calendar/Schedule.tsx
@@ -38,6 +38,7 @@ export type StyleSupplier<T> = (params: T) => StyleContainer;
 export interface Props<T extends object> {
   startDate: Date;
   endDate: Date;
+  interval: 'day' | 'week' | 'month';
   events: T[];
   showAllDayCell?: boolean;
   dateFormat?: (date: Date) => string;
@@ -80,8 +81,8 @@ export default function Schedule<T extends object>(props: Props<T>): React.React
         startAccessor={props.startAccessor}
         endAccessor={props.endAccessor}
         toolbar={false}
-        view="week"
-        views={['week']}
+        view={props.interval}
+        views={[props.interval]}
         formats={props.dateFormat ? {
           dayFormat: props.dateFormat,
         } : undefined}

--- a/optaweb-employee-rostering-frontend/src/ui/pages/availability/AvailabilityRosterPage.test.tsx
+++ b/optaweb-employee-rostering-frontend/src/ui/pages/availability/AvailabilityRosterPage.test.tsx
@@ -91,7 +91,7 @@ describe('Availability Roster Page', () => {
     />);
     const newDateStart = moment(startDate).add(7, 'days').toDate();
     const newDateEnd = moment(endDate).add(7, 'days').toDate();
-    availabilityRosterPage.find('WeekPicker[aria-label="Select Week to View"]')
+    availabilityRosterPage.find('IntervalPicker[aria-label="Select Interval to View"]')
       .simulate('change', newDateStart, newDateEnd);
     expect(baseProps.getAvailabilityRosterFor).toBeCalled();
     expect(baseProps.getAvailabilityRosterFor).toBeCalledWith({
@@ -651,5 +651,5 @@ const baseProps: Props = {
   addShift: jest.fn(),
   updateShift: jest.fn(),
   removeShift: jest.fn(),
-  ...getRouterProps<AvailabilityRosterUrlProps>('/shift', { employee: 'Employee 1', week: '2018-07-01' }),
+  ...getRouterProps<AvailabilityRosterUrlProps>('/shift', { employee: 'Employee 1', fromDate: '2018-07-01' }),
 };

--- a/optaweb-employee-rostering-frontend/src/ui/pages/availability/AvailabilityRosterPage.tsx
+++ b/optaweb-employee-rostering-frontend/src/ui/pages/availability/AvailabilityRosterPage.tsx
@@ -125,6 +125,7 @@ interface State {
   isCreatingOrEditingShift: boolean;
   selectedShift?: Shift;
   firstLoad: boolean;
+  interval: 'day' | 'week' | 'month';
 }
 
 export interface ShiftOrAvailability {
@@ -163,6 +164,7 @@ export class AvailabilityRosterPage extends React.Component<Props, State> {
       isCreatingOrEditingShift: false,
       isCreatingOrEditingAvailability: false,
       firstLoad: true,
+      interval: 'week',
     };
   }
 
@@ -391,6 +393,7 @@ export class AvailabilityRosterPage extends React.Component<Props, State> {
           <IntervalPicker
             aria-label="Select Interval to View"
             value={startDate}
+            interval={this.state.interval}
             onChange={(intervalStart, intervalEnd) => {
               this.onUpdateAvailabilityRoster({
                 ...urlProps,
@@ -398,6 +401,7 @@ export class AvailabilityRosterPage extends React.Component<Props, State> {
                 toDate: moment(intervalEnd).format('YYYY-MM-DD'),
               });
             }}
+            onIntervalChange={interval => this.setState({ interval })}
           />
           <ScoreDisplay score={score} />
           <Actions

--- a/optaweb-employee-rostering-frontend/src/ui/pages/availability/AvailabilityRosterPage.tsx
+++ b/optaweb-employee-rostering-frontend/src/ui/pages/availability/AvailabilityRosterPage.tsx
@@ -449,6 +449,7 @@ export class AvailabilityRosterPage extends React.Component<Props, State> {
           key={shownEmployee.id}
           startDate={startDate}
           endDate={endDate}
+          interval={this.state.interval}
           events={events}
           titleAccessor={soa => (isShift(soa.reference) ? soa.reference.spot.name : soa.reference.state)}
           startAccessor={soa => soa.start}

--- a/optaweb-employee-rostering-frontend/src/ui/pages/availability/__snapshots__/AvailabilityRosterPage.test.tsx.snap
+++ b/optaweb-employee-rostering-frontend/src/ui/pages/availability/__snapshots__/AvailabilityRosterPage.test.tsx.snap
@@ -98,8 +98,8 @@ exports[`Availability Roster Page should render correctly when creating a new av
         }
       }
     />
-    <WeekPicker
-      aria-label="Select Week to View"
+    <IntervalPicker
+      aria-label="Select Interval to View"
       onChange={[Function]}
       value={2018-07-01T00:00:00.000Z}
     />
@@ -395,8 +395,8 @@ exports[`Availability Roster Page should render correctly when loaded 1`] = `
         }
       }
     />
-    <WeekPicker
-      aria-label="Select Week to View"
+    <IntervalPicker
+      aria-label="Select Interval to View"
       onChange={[Function]}
       value={2018-07-01T00:00:00.000Z}
     />
@@ -720,8 +720,8 @@ exports[`Availability Roster Page should render correctly when solving 1`] = `
         }
       }
     />
-    <WeekPicker
-      aria-label="Select Week to View"
+    <IntervalPicker
+      aria-label="Select Interval to View"
       onChange={[Function]}
       value={2018-07-01T00:00:00.000Z}
     />

--- a/optaweb-employee-rostering-frontend/src/ui/pages/availability/__snapshots__/AvailabilityRosterPage.test.tsx.snap
+++ b/optaweb-employee-rostering-frontend/src/ui/pages/availability/__snapshots__/AvailabilityRosterPage.test.tsx.snap
@@ -100,7 +100,9 @@ exports[`Availability Roster Page should render correctly when creating a new av
     />
     <IntervalPicker
       aria-label="Select Interval to View"
+      interval="week"
       onChange={[Function]}
+      onIntervalChange={[Function]}
       value={2018-07-01T00:00:00.000Z}
     />
     <ScoreDisplay
@@ -397,7 +399,9 @@ exports[`Availability Roster Page should render correctly when loaded 1`] = `
     />
     <IntervalPicker
       aria-label="Select Interval to View"
+      interval="week"
       onChange={[Function]}
+      onIntervalChange={[Function]}
       value={2018-07-01T00:00:00.000Z}
     />
     <ScoreDisplay
@@ -722,7 +726,9 @@ exports[`Availability Roster Page should render correctly when solving 1`] = `
     />
     <IntervalPicker
       aria-label="Select Interval to View"
+      interval="week"
       onChange={[Function]}
+      onIntervalChange={[Function]}
       value={2018-07-01T00:00:00.000Z}
     />
     <ScoreDisplay

--- a/optaweb-employee-rostering-frontend/src/ui/pages/availability/__snapshots__/AvailabilityRosterPage.test.tsx.snap
+++ b/optaweb-employee-rostering-frontend/src/ui/pages/availability/__snapshots__/AvailabilityRosterPage.test.tsx.snap
@@ -285,6 +285,7 @@ exports[`Availability Roster Page should render correctly when creating a new av
         },
       ]
     }
+    interval="week"
     key="4"
     onAddEvent={[Function]}
     onUpdateEvent={[Function]}
@@ -584,6 +585,7 @@ exports[`Availability Roster Page should render correctly when loaded 1`] = `
         },
       ]
     }
+    interval="week"
     key="4"
     onAddEvent={[Function]}
     onUpdateEvent={[Function]}
@@ -911,6 +913,7 @@ exports[`Availability Roster Page should render correctly when solving 1`] = `
         },
       ]
     }
+    interval="week"
     key="4"
     onAddEvent={[Function]}
     onUpdateEvent={[Function]}

--- a/optaweb-employee-rostering-frontend/src/ui/pages/rotation/RotationPage.tsx
+++ b/optaweb-employee-rostering-frontend/src/ui/pages/rotation/RotationPage.tsx
@@ -339,6 +339,7 @@ export class RotationPage extends React.Component<Props & WithTranslation, State
           key={shownSpot.id}
           startDate={startDate}
           endDate={endDate}
+          interval="week"
           dateFormat={date => this.props.t('rotationDay',
             {
               day: moment.duration(moment(date).diff(baseDate)).asDays() + 1,

--- a/optaweb-employee-rostering-frontend/src/ui/pages/rotation/__snapshots__/RotationPage.test.tsx.snap
+++ b/optaweb-employee-rostering-frontend/src/ui/pages/rotation/__snapshots__/RotationPage.test.tsx.snap
@@ -184,6 +184,7 @@ exports[`Rotation Page should render correctly when creating a new shift templat
         },
       ]
     }
+    interval="week"
     key="2"
     onAddEvent={[Function]}
     onUpdateEvent={[Function]}
@@ -381,6 +382,7 @@ exports[`Rotation Page should render correctly when loaded 1`] = `
         },
       ]
     }
+    interval="week"
     key="2"
     onAddEvent={[Function]}
     onUpdateEvent={[Function]}

--- a/optaweb-employee-rostering-frontend/src/ui/pages/shift/ShiftRosterPage.test.tsx
+++ b/optaweb-employee-rostering-frontend/src/ui/pages/shift/ShiftRosterPage.test.tsx
@@ -122,7 +122,7 @@ describe('Shift Roster Page', () => {
     />);
     const newDateStart = moment(startDate).add(7, 'days').toDate();
     const newDateEnd = moment(endDate).add(7, 'days').toDate();
-    shiftRosterPage.find('[aria-label="Select Week to View"]').simulate('change', newDateStart, newDateEnd);
+    shiftRosterPage.find('[aria-label="Select Interval to View"]').simulate('change', newDateStart, newDateEnd);
     expect(baseProps.getShiftRosterFor).toBeCalled();
     expect(baseProps.getShiftRosterFor).toBeCalledWith({
       fromDate: newDateStart,
@@ -453,5 +453,5 @@ const baseProps: Props = {
   publishRoster: jest.fn(),
   terminateSolvingRosterEarly: jest.fn(),
   showInfoMessage: jest.fn(),
-  ...getRouterProps<ShiftRosterUrlProps>('/shift', { spot: 'Spot', week: '2018-07-01' }),
+  ...getRouterProps<ShiftRosterUrlProps>('/shift', { spot: 'Spot', fromDate: '2018-07-01' }),
 };

--- a/optaweb-employee-rostering-frontend/src/ui/pages/shift/ShiftRosterPage.tsx
+++ b/optaweb-employee-rostering-frontend/src/ui/pages/shift/ShiftRosterPage.tsx
@@ -341,6 +341,7 @@ export class ShiftRosterPage extends React.Component<Props, State> {
           key={this.props.shownSpotList[0].id}
           startDate={startDate}
           endDate={endDate}
+          interval={this.state.interval}
           events={this.props.spotIdToShiftListMap.get(shownSpot.id as number) || []}
           titleAccessor={shift => (shift.employee ? shift.employee.name : t('unassigned'))}
           startAccessor={shift => moment(shift.startDateTime).toDate()}

--- a/optaweb-employee-rostering-frontend/src/ui/pages/shift/ShiftRosterPage.tsx
+++ b/optaweb-employee-rostering-frontend/src/ui/pages/shift/ShiftRosterPage.tsx
@@ -105,6 +105,7 @@ interface State {
   isCreatingOrEditingShift: boolean;
   selectedShift?: Shift;
   firstLoad: boolean;
+  interval: 'day' | 'week' | 'month';
 }
 
 export class ShiftRosterPage extends React.Component<Props, State> {
@@ -119,6 +120,7 @@ export class ShiftRosterPage extends React.Component<Props, State> {
     this.state = {
       isCreatingOrEditingShift: false,
       firstLoad: true,
+      interval: 'week',
     };
   }
 
@@ -301,6 +303,7 @@ export class ShiftRosterPage extends React.Component<Props, State> {
           <IntervalPicker
             aria-label="Select Interval to View"
             value={startDate}
+            interval={this.state.interval}
             onChange={(intervalStart, intervalEnd) => {
               this.onUpdateShiftRoster({
                 ...urlProps,
@@ -308,6 +311,7 @@ export class ShiftRosterPage extends React.Component<Props, State> {
                 toDate: moment(intervalEnd).format('YYYY-MM-DD'),
               });
             }}
+            onIntervalChange={interval => this.setState({ interval })}
           />
           <ScoreDisplay score={score} />
           <Actions

--- a/optaweb-employee-rostering-frontend/src/ui/pages/shift/__snapshots__/ShiftRosterPage.test.tsx.snap
+++ b/optaweb-employee-rostering-frontend/src/ui/pages/shift/__snapshots__/ShiftRosterPage.test.tsx.snap
@@ -70,7 +70,9 @@ exports[`Shift Roster Page should render correctly when creating a new shift via
     />
     <IntervalPicker
       aria-label="Select Interval to View"
+      interval="week"
       onChange={[Function]}
+      onIntervalChange={[Function]}
       value={2018-07-01T00:00:00.000Z}
     />
     <ScoreDisplay
@@ -288,7 +290,9 @@ exports[`Shift Roster Page should render correctly when loaded 1`] = `
     />
     <IntervalPicker
       aria-label="Select Interval to View"
+      interval="week"
       onChange={[Function]}
+      onIntervalChange={[Function]}
       value={2018-07-01T00:00:00.000Z}
     />
     <ScoreDisplay
@@ -534,7 +538,9 @@ exports[`Shift Roster Page should render correctly when solving 1`] = `
     />
     <IntervalPicker
       aria-label="Select Interval to View"
+      interval="week"
       onChange={[Function]}
+      onIntervalChange={[Function]}
       value={2018-07-01T00:00:00.000Z}
     />
     <ScoreDisplay

--- a/optaweb-employee-rostering-frontend/src/ui/pages/shift/__snapshots__/ShiftRosterPage.test.tsx.snap
+++ b/optaweb-employee-rostering-frontend/src/ui/pages/shift/__snapshots__/ShiftRosterPage.test.tsx.snap
@@ -68,8 +68,8 @@ exports[`Shift Roster Page should render correctly when creating a new shift via
         }
       }
     />
-    <WeekPicker
-      aria-label="Select Week to View"
+    <IntervalPicker
+      aria-label="Select Interval to View"
       onChange={[Function]}
       value={2018-07-01T00:00:00.000Z}
     />
@@ -286,8 +286,8 @@ exports[`Shift Roster Page should render correctly when loaded 1`] = `
         }
       }
     />
-    <WeekPicker
-      aria-label="Select Week to View"
+    <IntervalPicker
+      aria-label="Select Interval to View"
       onChange={[Function]}
       value={2018-07-01T00:00:00.000Z}
     />
@@ -532,8 +532,8 @@ exports[`Shift Roster Page should render correctly when solving 1`] = `
         }
       }
     />
-    <WeekPicker
-      aria-label="Select Week to View"
+    <IntervalPicker
+      aria-label="Select Interval to View"
       onChange={[Function]}
       value={2018-07-01T00:00:00.000Z}
     />

--- a/optaweb-employee-rostering-frontend/src/ui/pages/shift/__snapshots__/ShiftRosterPage.test.tsx.snap
+++ b/optaweb-employee-rostering-frontend/src/ui/pages/shift/__snapshots__/ShiftRosterPage.test.tsx.snap
@@ -207,6 +207,7 @@ exports[`Shift Roster Page should render correctly when creating a new shift via
         },
       ]
     }
+    interval="week"
     key="2"
     onAddEvent={[Function]}
     onUpdateEvent={[Function]}
@@ -427,6 +428,7 @@ exports[`Shift Roster Page should render correctly when loaded 1`] = `
         },
       ]
     }
+    interval="week"
     key="2"
     onAddEvent={[Function]}
     onUpdateEvent={[Function]}
@@ -675,6 +677,7 @@ exports[`Shift Roster Page should render correctly when solving 1`] = `
         },
       ]
     }
+    interval="week"
     key="2"
     onAddEvent={[Function]}
     onUpdateEvent={[Function]}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/10572368/74828517-329c2280-534a-11ea-8272-ce355af740fb.png)

Give users the ability to look at their availability or shift rosters by toggling between day, week and month views

- Rename WeekPicker to IntervalPicker, and update all references
- Give IntervalPicker the ability to toggle between day/week/month views
- Rostering pages
  - Use the start/end dates given by IntervalPicker instead of recomputing from scratch
  - Hold the desired interval as a state field, injecting this into IntervalPicker
  - Let IntervalPicker change the page interval through a callback, in turn influencing the calendar view in Schedule